### PR TITLE
fix: Switch release format from PKG to DMG

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,12 +67,13 @@ jobs:
             CODE_SIGNING_ALLOWED=NO \
             build
 
-      - name: Create PKG
-        id: pkg
+      - name: Create DMG
+        id: dmg
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           APP_PATH="build/Build/Products/Release/ZoomacIt.app"
-          PKG_NAME="ZoomacIt-v${VERSION}.pkg"
+          DMG_NAME="ZoomacIt-v${VERSION}.dmg"
+          STAGING_DIR="dmg-staging"
 
           # Verify .app exists
           if [ ! -d "$APP_PATH" ]; then
@@ -81,14 +82,22 @@ jobs:
             exit 1
           fi
 
-          # Create PKG installer
-          productbuild \
-            --component "$APP_PATH" /Applications \
-            "$PKG_NAME"
+          # Create staging directory with .app and Applications symlink
+          mkdir -p "$STAGING_DIR"
+          cp -R "$APP_PATH" "$STAGING_DIR/"
+          ln -s /Applications "$STAGING_DIR/Applications"
 
-          echo "pkg_name=$PKG_NAME" >> "$GITHUB_OUTPUT"
-          echo "Created: $PKG_NAME"
-          ls -lh "$PKG_NAME"
+          # Create DMG
+          hdiutil create \
+            -volname "ZoomacIt" \
+            -srcfolder "$STAGING_DIR" \
+            -ov \
+            -format UDZO \
+            "$DMG_NAME"
+
+          echo "dmg_name=$DMG_NAME" >> "$GITHUB_OUTPUT"
+          echo "Created: $DMG_NAME"
+          ls -lh "$DMG_NAME"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -98,11 +107,12 @@ jobs:
           draft: false
           prerelease: false
           generate_release_notes: true
-          files: ${{ steps.pkg.outputs.pkg_name }}
+          files: ${{ steps.dmg.outputs.dmg_name }}
           body: |
             ## Installation
 
-            1. Download **${{ steps.pkg.outputs.pkg_name }}** below
-            2. Right-click the `.pkg` file → **Open** → Click **Open** in the dialog (required for unsigned apps)
-            3. Follow the installer to install ZoomacIt to Applications
-            4. Grant **Screen Recording** permission when prompted
+            1. Download **${{ steps.dmg.outputs.dmg_name }}** below
+            2. Open the `.dmg` file
+            3. Drag **ZoomacIt.app** to the **Applications** folder
+            4. Right-click ZoomacIt.app in Applications → **Open** → Click **Open** in the dialog (required for unsigned apps)
+            5. Grant **Screen Recording** permission when prompted

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ The project aims for feature compatibility with ZoomIt, providing system-wide ho
 
 ## Installation
 
-1. Download the latest `.pkg` from [Releases](https://github.com/07JP27/ZoomacIt/releases)
-2. Right-click the `.pkg` file → **Open** → Click **Open** in the dialog  
+1. Download the latest `.dmg` from [Releases](https://github.com/07JP27/ZoomacIt/releases)
+2. Open the `.dmg` file and drag **ZoomacIt.app** to the **Applications** folder
+3. Right-click ZoomacIt.app in Applications → **Open** → Click **Open** in the dialog  
    *(Required because the app is not signed with an Apple Developer ID)*
-3. Follow the installer to install ZoomacIt to Applications
 4. Grant **Screen Recording** permission when prompted
 
 ## Current feature coverage

--- a/README_ja.md
+++ b/README_ja.md
@@ -10,10 +10,10 @@ ZoomIt との機能互換を目指しており、システム全体で使える�
 
 ## インストール
 
-1. [Releases](https://github.com/07JP27/ZoomacIt/releases) から最新の `.pkg` をダウンロード
-2. `.pkg` ファイルを右クリック → **開く** → ダイアログで **開く** をクリック  
+1. [Releases](https://github.com/07JP27/ZoomacIt/releases) から最新の `.dmg` をダウンロード
+2. `.dmg` を開き、**ZoomacIt.app** を **Applications** フォルダにドラッグ
+3. Applications の ZoomacIt.app を右クリック → **開く** → ダイアログで **開く** をクリック  
    *（Apple Developer ID で署名されていないため必要です）*
-3. インストーラーに従って ZoomacIt を Applications にインストール
 4. プロンプトが表示されたら **画面収録** 権限を許可
 
 ## 現在の機能カバレッジ


### PR DESCRIPTION
未署名のPKGはGatekeeperにブロックされ右クリック→「開く」でも開けない問題を修正。

## Changes
- Release artifact を PKG → DMG に変更（`hdiutil` で作成、Applications シンボリックリンク付き）
- README.md / README_ja.md のインストール手順を DMG 用に更新

## Why
未署名の `.pkg` は macOS Gatekeeper に厳しくブロックされ、右クリック→「開く」でもマルウェア警告で開けない。`.app` を含む DMG であれば右クリック→「開く」で正常に起動できる。