### PR TITLE
Zoom to mouse cursor position on entry

### DIFF
--- a/src/ZoomacIt/Overlay/StillZoomWindowController.swift
+++ b/src/ZoomacIt/Overlay/StillZoomWindowController.swift
@@ -47,7 +47,20 @@ final class StillZoomWindowController {
                 )
                 NSLog("[StillZoomWindowController] Capture succeeded: %dx%d", captured.width, captured.height)
                 self.sourceImage = captured
-                self.presentOverlay(on: screen, image: captured, scaleFactor: scaleFactor)
+
+                // Convert current mouse position to image pixel coordinates
+                let mouseScreen = NSEvent.mouseLocation
+                let mouseInView = CGPoint(
+                    x: mouseScreen.x - screen.frame.origin.x,
+                    y: mouseScreen.y - screen.frame.origin.y
+                )
+                let mousePanCenter = CGPoint(
+                    x: mouseInView.x * scaleFactor,
+                    y: mouseInView.y * scaleFactor
+                )
+
+                self.presentOverlay(on: screen, image: captured, scaleFactor: scaleFactor,
+                                    initialPanCenter: mousePanCenter)
             } catch {
                 NSLog("[StillZoomWindowController] Screen capture failed: %@", error.localizedDescription)
                 self.onShowFailed?()


### PR DESCRIPTION
## Changes

Still Zoom mode の初期ズームアニメーションを、画面中央ではなくマウスカーソル位置に向かってズームするように変更。

### Before
1. ⌃1 → 画面中央に向かってズームアニメーション
2. マウス移動 → カーソル位置にジャンプ（不自然）

### After
1. ⌃1 → マウスカーソル位置に向かって直接ズームアニメーション
2. マウス移動 → そのままスムーズに追従

### Implementation
`showZoomOverlay()` で `NSEvent.mouseLocation` を取得し、スクリーン座標からimage pixel座標に変換して `initialPanCenter` として `presentOverlay()` に渡すようにした。`StillZoomView` の `init` は既に `initialPanCenter` パラメータを受け取る設計だったため、View側の変更は不要。