### PR TITLE
Document maintenance workflow and contributors

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,15 +1,17 @@
 name: Deploy Docs
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'docs/**'
+  workflow_run:
+    workflows: ['Release']
+    types: [completed]
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions:
   pages: write
   id-token: write
+  contents: read
 
 concurrency:
   group: pages
@@ -18,9 +20,14 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # When triggered by workflow_run, only deploy if the upstream Release
+    # workflow succeeded. workflow_dispatch runs always proceed.
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: main
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,9 @@
+# Contributors
+
+Thank you to everyone who contributes to ZoomacIt through code, documentation, design feedback, bug reports, feature requests, and community support.
+
+GitHub maintains the canonical contributor list for this repository:
+
+https://github.com/07JP27/ZoomacIt/graphs/contributors
+
+If you contributed in a way that is not reflected there, please open an issue or pull request so we can acknowledge it.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
   <a href="https://github.com/07JP27/ZoomacIt/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/07JP27/ZoomacIt/ci.yml?style=flat&label=CI" alt="CI"></a>
   <a href="https://github.com/07JP27/ZoomacIt/releases/latest"><img src="https://img.shields.io/github/v/release/07JP27/ZoomacIt?style=flat" alt="Release"></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/07JP27/ZoomacIt?style=flat" alt="License"></a>
+  <a href="CONTRIBUTORS.md"><img src="https://img.shields.io/github/contributors/07JP27/ZoomacIt?style=flat" alt="Contributors"></a>
   <img src="https://img.shields.io/badge/Swift-6.0-orange?style=flat&logo=swift&logoColor=white" alt="Swift 6.0">
   <img src="https://img.shields.io/badge/macOS-26%2B-blue?style=flat&logo=apple&logoColor=white" alt="macOS 26+">
   <a href="https://github.com/sponsors/07JP27"><img src="https://img.shields.io/badge/Sponsor-%E2%9D%A4-ea4aaa?style=flat&logo=githubsponsors&logoColor=white" alt="Sponsor"></a>
@@ -101,6 +102,10 @@ make dmg VERSION=1.0.0
 This builds a Release binary signed with your Developer ID, submits it to Apple for notarization, staples the notarization ticket, and packages the result into a distributable DMG.
 
 > **Note:** Notarization requires an [Apple Developer Program](https://developer.apple.com/programs/) membership. The `.env` file is gitignored and must never be committed.
+
+## Contributors
+
+Thanks to everyone who helps improve ZoomacIt. See [CONTRIBUTORS.md](CONTRIBUTORS.md) for acknowledgments.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ This builds a Release binary signed with your Developer ID, submits it to Apple 
 
 ## Contributors
 
+<a href="https://github.com/07JP27/ZoomacIt/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=07JP27/ZoomacIt" alt="Contributors" />
+</a>
+
 Thanks to everyone who helps improve ZoomacIt. See [CONTRIBUTORS.md](CONTRIBUTORS.md) for acknowledgments.
 
 ## License

--- a/README_ja.md
+++ b/README_ja.md
@@ -6,6 +6,7 @@
   <a href="https://github.com/07JP27/ZoomacIt/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/07JP27/ZoomacIt/ci.yml?style=flat&label=CI" alt="CI"></a>
   <a href="https://github.com/07JP27/ZoomacIt/releases/latest"><img src="https://img.shields.io/github/v/release/07JP27/ZoomacIt?style=flat" alt="Release"></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/07JP27/ZoomacIt?style=flat" alt="License"></a>
+  <a href="CONTRIBUTORS.md"><img src="https://img.shields.io/github/contributors/07JP27/ZoomacIt?style=flat" alt="Contributors"></a>
   <img src="https://img.shields.io/badge/Swift-6.0-orange?style=flat&logo=swift&logoColor=white" alt="Swift 6.0">
   <img src="https://img.shields.io/badge/macOS-26%2B-blue?style=flat&logo=apple&logoColor=white" alt="macOS 26+">
   <a href="https://github.com/sponsors/07JP27"><img src="https://img.shields.io/badge/Sponsor-%E2%9D%A4-ea4aaa?style=flat&logo=githubsponsors&logoColor=white" alt="Sponsor"></a>
@@ -101,6 +102,10 @@ make dmg VERSION=1.0.0
 Developer ID で署名されたリリースバイナリをビルドし、Apple に公証を申請し、公証チケットをステープルし、配布用 DMG にパッケージします。
 
 > **注意:** 公証には [Apple Developer Program](https://developer.apple.com/programs/) のメンバーシップが必要です。`.env` ファイルは gitignore に含まれており、コミットしないでください。
+
+## コントリビューター
+
+ZoomacIt の改善に協力してくださるすべての方に感謝します。謝辞は [CONTRIBUTORS.md](CONTRIBUTORS.md) をご覧ください。
 
 ## ライセンス
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -105,6 +105,10 @@ Developer ID で署名されたリリースバイナリをビルドし、Apple �
 
 ## コントリビューター
 
+<a href="https://github.com/07JP27/ZoomacIt/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=07JP27/ZoomacIt" alt="Contributors" />
+</a>
+
 ZoomacIt の改善に協力してくださるすべての方に感謝します。謝辞は [CONTRIBUTORS.md](CONTRIBUTORS.md) をご覧ください。
 
 ## ライセンス


### PR DESCRIPTION
## Summary
- Align docs deployment with release creation timing by deploying after the Release workflow succeeds or a GitHub release is published
- Keep manual docs deployment via workflow_dispatch and build docs from main
- Add CONTRIBUTORS.md plus README/README_ja contributor badges, acknowledgment links, and contrib.rocks contributor icon grids

## Validation
- `cd docs && npm ci --no-audit --no-fund`
- `make docs-build`
- `make test`

Closes #30