### PR TITLE
feat(Draw): pen cursor matches colour, size, and active shape tool

### DIFF
--- a/src/ZoomacIt/Draw/DrawingCanvasView.swift
+++ b/src/ZoomacIt/Draw/DrawingCanvasView.swift
@@ -73,11 +73,12 @@ final class DrawingCanvasView: NSView {
             cursor = Self.spotlightCursor
         default:
             let mods = NSEvent.modifierFlags.intersection([.shift, .control])
-            if mods.isEmpty && !drawingState.isTabHeld {
+            if drawingState.isTabHeld {
+                cursor = shapeCursor(for: [])  // ellipse — Tab takes precedence
+            } else if mods.isEmpty {
                 cursor = penCursor()
             } else {
-                cursor = shapeCursor(for: mods.isEmpty && drawingState.isTabHeld
-                    ? [] : mods)
+                cursor = shapeCursor(for: mods)
             }
         }
         addCursorRect(bounds, cursor: cursor)
@@ -537,6 +538,7 @@ final class DrawingCanvasView: NSView {
         // Tab key for ellipse (track as key, not modifier)
         case "\t":
             drawingState.isTabHeld = true
+            updateCursorForTool()
 
         // Space — move cursor to center
         case " ":
@@ -608,6 +610,7 @@ final class DrawingCanvasView: NSView {
         guard let characters = event.charactersIgnoringModifiers else { return }
         if characters == "\t" {
             drawingState.isTabHeld = false
+            updateCursorForTool()
         }
     }
 

--- a/src/ZoomacIt/Draw/DrawingCanvasView.swift
+++ b/src/ZoomacIt/Draw/DrawingCanvasView.swift
@@ -72,19 +72,14 @@ final class DrawingCanvasView: NSView {
         case .spotlight:
             cursor = Self.spotlightCursor
         default:
-            let mods = NSEvent.modifierFlags.intersection([.shift, .control])
-            if drawingState.isTabHeld {
-                cursor = shapeCursor(for: [])  // ellipse — Tab takes precedence
-            } else if mods.isEmpty {
-                cursor = penCursor()
-            } else {
-                cursor = shapeCursor(for: mods)
-            }
+            let mods = NSEvent.modifierFlags.intersection(.deviceIndependentFlagsMask)
+            let shapeType = drawingState.currentShapeType(modifiers: mods)
+            cursor = shapeType == .freehand ? penCursor() : crosshairCursor()
         }
         addCursorRect(bounds, cursor: cursor)
     }
 
-    /// Generates a circular cursor matching the current pen colour and width.
+    /// Generates a circular cursor matching the current pen colour and width (freehand mode).
     private func penCursor() -> NSCursor {
         let penWidth = drawingState.penWidth
         let color = drawingState.currentNSColor
@@ -106,75 +101,53 @@ final class DrawingCanvasView: NSView {
         return NSCursor(image: image, hotSpot: hotSpot)
     }
 
-    /// Generates a shape-indicator cursor based on held modifiers.
-    private func shapeCursor(for modifiers: NSEvent.ModifierFlags) -> NSCursor {
+    /// Generates a crosshair cursor scaled by pen width (shape modes).
+    private func crosshairCursor() -> NSCursor {
+        let penWidth = drawingState.penWidth
         let color = drawingState.currentNSColor
+        let armLength = min(max(penWidth * 1.5, 8), 40)
+        let thickness = min(max(penWidth, 1), 10)
+        let size = armLength * 2 + thickness + 6
+        let center = size / 2
 
-        if modifiers.contains(.shift) && modifiers.contains(.control) {
-            // Arrow — rotates with drag direction
-            return rotatingCursor(angle: dragAngle, color: color, withHead: true)
-        } else if modifiers.contains(.control) {
-            // Rectangle — small filled square (hidden during drag)
-            if isDragging { return .crosshair }
-            return smallSquareCursor(color: color)
-        } else if modifiers.contains(.shift) {
-            // Line — rotates with drag direction
-            return rotatingCursor(angle: dragAngle, color: color, withHead: false)
-        } else {
-            // Ellipse (Tab) — small circle (hidden during drag)
-            if isDragging { return .crosshair }
-            return smallCircleCursor(color: color)
-        }
-    }
-
-    private func rotatingCursor(angle: CGFloat, color: NSColor, withHead: Bool) -> NSCursor {
-        let size: CGFloat = 20
         let image = NSImage(size: NSSize(width: size, height: size), flipped: false) { _ in
-            let ctx = NSGraphicsContext.current!.cgContext
-            ctx.translateBy(x: size / 2, y: size / 2)
-            ctx.rotate(by: angle)
+            // Outer contrast stroke (black)
+            NSColor.black.withAlphaComponent(0.4).setStroke()
+            let outerH = NSBezierPath()
+            outerH.move(to: NSPoint(x: center - armLength, y: center))
+            outerH.line(to: NSPoint(x: center + armLength, y: center))
+            outerH.lineWidth = thickness + 2
+            outerH.lineCapStyle = .round
+            outerH.stroke()
+
+            let outerV = NSBezierPath()
+            outerV.move(to: NSPoint(x: center, y: center - armLength))
+            outerV.line(to: NSPoint(x: center, y: center + armLength))
+            outerV.lineWidth = thickness + 2
+            outerV.lineCapStyle = .round
+            outerV.stroke()
+
+            // Inner colored stroke
             color.setStroke()
-            color.setFill()
-            let path = NSBezierPath()
-            path.move(to: NSPoint(x: -7, y: 0))
-            path.line(to: NSPoint(x: 7, y: 0))
-            path.lineWidth = 2
-            path.stroke()
-            if withHead {
-                let head = NSBezierPath()
-                head.move(to: NSPoint(x: 7, y: 0))
-                head.line(to: NSPoint(x: 3, y: 3))
-                head.line(to: NSPoint(x: 3, y: -3))
-                head.close()
-                head.fill()
-            }
+            let innerH = NSBezierPath()
+            innerH.move(to: NSPoint(x: center - armLength, y: center))
+            innerH.line(to: NSPoint(x: center + armLength, y: center))
+            innerH.lineWidth = thickness
+            innerH.lineCapStyle = .round
+            innerH.stroke()
+
+            let innerV = NSBezierPath()
+            innerV.move(to: NSPoint(x: center, y: center - armLength))
+            innerV.line(to: NSPoint(x: center, y: center + armLength))
+            innerV.lineWidth = thickness
+            innerV.lineCapStyle = .round
+            innerV.stroke()
+
             return true
         }
-        return NSCursor(image: image, hotSpot: NSPoint(x: size / 2, y: size / 2))
-    }
 
-    private func smallSquareCursor(color: NSColor) -> NSCursor {
-        let size: CGFloat = 10
-        let image = NSImage(size: NSSize(width: size, height: size), flipped: false) { _ in
-            color.setFill()
-            NSBezierPath(rect: NSRect(x: 1, y: 1, width: size - 2, height: size - 2)).fill()
-            return true
-        }
-        return NSCursor(image: image, hotSpot: NSPoint(x: size / 2, y: size / 2))
+        return NSCursor(image: image, hotSpot: NSPoint(x: center, y: center))
     }
-
-    private func smallCircleCursor(color: NSColor) -> NSCursor {
-        let size: CGFloat = 10
-        let image = NSImage(size: NSSize(width: size, height: size), flipped: false) { _ in
-            color.setFill()
-            NSBezierPath(ovalIn: NSRect(x: 1, y: 1, width: size - 2, height: size - 2)).fill()
-            return true
-        }
-        return NSCursor(image: image, hotSpot: NSPoint(x: size / 2, y: size / 2))
-    }
-
-    /// Current drag angle for rotating cursors (radians, 0 = right).
-    private var dragAngle: CGFloat = 0
 
     /// Minimum width and height (points) for a spotlight rectangle to be confirmed
     /// on mouseUp. Drags smaller than this are treated as accidental clicks /
@@ -392,16 +365,8 @@ final class DrawingCanvasView: NSView {
             activeFreehand = nil
 
         case .arrow:
-            previewLayer = ShapeRenderer.arrowPath(from: dragOrigin, to: currentPoint)
+            previewLayer = ShapeRenderer.arrowPath(from: dragOrigin, to: currentPoint, penWidth: drawingState.penWidth)
             activeFreehand = nil
-        }
-
-        // Update drag angle for rotating cursors (arrow/line)
-        let dx = currentPoint.x - dragOrigin.x
-        let dy = currentPoint.y - dragOrigin.y
-        if dx * dx + dy * dy > 9 { // only update if dragged > 3pt
-            dragAngle = atan2(dy, dx)
-            updateCursorForTool()
         }
 
         setNeedsDisplay(bounds)
@@ -566,6 +531,17 @@ final class DrawingCanvasView: NSView {
         case "S" where modifiers.intersection([.command, .control, .option, .shift]).isEmpty:
             toggleSpotlightTool()
 
+        // Arrow keys — pen size (when no spotlight rect; ZoomIt-compatible)
+        case String(UnicodeScalar(NSUpArrowFunctionKey)!)
+            where drawingState.spotlightRect == nil:
+            drawingState.increasePenWidth()
+            updateCursorForTool()
+
+        case String(UnicodeScalar(NSDownArrowFunctionKey)!)
+            where drawingState.spotlightRect == nil:
+            drawingState.decreasePenWidth()
+            updateCursorForTool()
+
         // Spotlight darkness — only meaningful when a spotlight rect exists
         case String(UnicodeScalar(NSUpArrowFunctionKey)!)
             where drawingState.spotlightRect != nil
@@ -628,23 +604,19 @@ final class DrawingCanvasView: NSView {
     // MARK: - Scroll Wheel (Pen Size)
 
     override func scrollWheel(with event: NSEvent) {
-        let modifiers = event.modifierFlags
-
         if drawingState.isTextMode {
             // In text mode, scroll wheel changes font size
             textInputController?.adjustFontSize(delta: event.scrollingDeltaY)
             return
         }
 
-        if modifiers.contains(.control) {
-            // ⌃ + scroll wheel → pen size
-            if event.scrollingDeltaY > 0 {
-                drawingState.increasePenWidth()
-            } else if event.scrollingDeltaY < 0 {
-                drawingState.decreasePenWidth()
-            }
-            updateCursorForTool()
+        // Scroll wheel → pen size (also works with Ctrl held for ZoomIt compatibility)
+        if event.scrollingDeltaY > 0 {
+            drawingState.increasePenWidth()
+        } else if event.scrollingDeltaY < 0 {
+            drawingState.decreasePenWidth()
         }
+        updateCursorForTool()
     }
 
     // MARK: - Compositing
@@ -693,7 +665,7 @@ final class DrawingCanvasView: NSView {
         case .ellipse:
             path = ShapeRenderer.ellipsePath(from: dragOrigin, to: endPoint).cgPath
         case .arrow:
-            path = ShapeRenderer.arrowPath(from: dragOrigin, to: endPoint).cgPath
+            path = ShapeRenderer.arrowPath(from: dragOrigin, to: endPoint, penWidth: drawingState.penWidth).cgPath
         }
 
         bitmapContext.addPath(path)

--- a/src/ZoomacIt/Draw/DrawingCanvasView.swift
+++ b/src/ZoomacIt/Draw/DrawingCanvasView.swift
@@ -67,11 +67,113 @@ final class DrawingCanvasView: NSView {
     // MARK: - Cursor
 
     override func resetCursorRects() {
-        let cursor: NSCursor = (drawingState.activeTool == .spotlight)
-            ? Self.spotlightCursor
-            : .crosshair
+        let cursor: NSCursor
+        switch drawingState.activeTool {
+        case .spotlight:
+            cursor = Self.spotlightCursor
+        default:
+            let mods = NSEvent.modifierFlags.intersection([.shift, .control])
+            if mods.isEmpty && !drawingState.isTabHeld {
+                cursor = penCursor()
+            } else {
+                cursor = shapeCursor(for: mods.isEmpty && drawingState.isTabHeld
+                    ? [] : mods)
+            }
+        }
         addCursorRect(bounds, cursor: cursor)
     }
+
+    /// Generates a circular cursor matching the current pen colour and width.
+    private func penCursor() -> NSCursor {
+        let penWidth = drawingState.penWidth
+        let color = drawingState.currentNSColor
+        let size = max(penWidth * 2, 8)
+        let imageSize = NSSize(width: size + 4, height: size + 4)
+
+        let image = NSImage(size: imageSize, flipped: false) { _ in
+            let rect = NSRect(x: 2, y: 2, width: size, height: size)
+            color.setFill()
+            NSBezierPath(ovalIn: rect).fill()
+            NSColor.white.withAlphaComponent(0.8).setStroke()
+            let border = NSBezierPath(ovalIn: rect)
+            border.lineWidth = 0.5
+            border.stroke()
+            return true
+        }
+
+        let hotSpot = NSPoint(x: imageSize.width / 2, y: imageSize.height / 2)
+        return NSCursor(image: image, hotSpot: hotSpot)
+    }
+
+    /// Generates a shape-indicator cursor based on held modifiers.
+    private func shapeCursor(for modifiers: NSEvent.ModifierFlags) -> NSCursor {
+        let color = drawingState.currentNSColor
+
+        if modifiers.contains(.shift) && modifiers.contains(.control) {
+            // Arrow — rotates with drag direction
+            return rotatingCursor(angle: dragAngle, color: color, withHead: true)
+        } else if modifiers.contains(.control) {
+            // Rectangle — small filled square (hidden during drag)
+            if isDragging { return .crosshair }
+            return smallSquareCursor(color: color)
+        } else if modifiers.contains(.shift) {
+            // Line — rotates with drag direction
+            return rotatingCursor(angle: dragAngle, color: color, withHead: false)
+        } else {
+            // Ellipse (Tab) — small circle (hidden during drag)
+            if isDragging { return .crosshair }
+            return smallCircleCursor(color: color)
+        }
+    }
+
+    private func rotatingCursor(angle: CGFloat, color: NSColor, withHead: Bool) -> NSCursor {
+        let size: CGFloat = 20
+        let image = NSImage(size: NSSize(width: size, height: size), flipped: false) { _ in
+            let ctx = NSGraphicsContext.current!.cgContext
+            ctx.translateBy(x: size / 2, y: size / 2)
+            ctx.rotate(by: angle)
+            color.setStroke()
+            color.setFill()
+            let path = NSBezierPath()
+            path.move(to: NSPoint(x: -7, y: 0))
+            path.line(to: NSPoint(x: 7, y: 0))
+            path.lineWidth = 2
+            path.stroke()
+            if withHead {
+                let head = NSBezierPath()
+                head.move(to: NSPoint(x: 7, y: 0))
+                head.line(to: NSPoint(x: 3, y: 3))
+                head.line(to: NSPoint(x: 3, y: -3))
+                head.close()
+                head.fill()
+            }
+            return true
+        }
+        return NSCursor(image: image, hotSpot: NSPoint(x: size / 2, y: size / 2))
+    }
+
+    private func smallSquareCursor(color: NSColor) -> NSCursor {
+        let size: CGFloat = 10
+        let image = NSImage(size: NSSize(width: size, height: size), flipped: false) { _ in
+            color.setFill()
+            NSBezierPath(rect: NSRect(x: 1, y: 1, width: size - 2, height: size - 2)).fill()
+            return true
+        }
+        return NSCursor(image: image, hotSpot: NSPoint(x: size / 2, y: size / 2))
+    }
+
+    private func smallCircleCursor(color: NSColor) -> NSCursor {
+        let size: CGFloat = 10
+        let image = NSImage(size: NSSize(width: size, height: size), flipped: false) { _ in
+            color.setFill()
+            NSBezierPath(ovalIn: NSRect(x: 1, y: 1, width: size - 2, height: size - 2)).fill()
+            return true
+        }
+        return NSCursor(image: image, hotSpot: NSPoint(x: size / 2, y: size / 2))
+    }
+
+    /// Current drag angle for rotating cursors (radians, 0 = right).
+    private var dragAngle: CGFloat = 0
 
     /// Minimum width and height (points) for a spotlight rectangle to be confirmed
     /// on mouseUp. Drags smaller than this are treated as accidental clicks /
@@ -293,6 +395,14 @@ final class DrawingCanvasView: NSView {
             activeFreehand = nil
         }
 
+        // Update drag angle for rotating cursors (arrow/line)
+        let dx = currentPoint.x - dragOrigin.x
+        let dy = currentPoint.y - dragOrigin.y
+        if dx * dx + dy * dy > 9 { // only update if dragged > 3pt
+            dragAngle = atan2(dy, dx)
+            updateCursorForTool()
+        }
+
         setNeedsDisplay(bounds)
     }
 
@@ -385,6 +495,7 @@ final class DrawingCanvasView: NSView {
                 if drawingState.isTextMode {
                     textInputController?.updateColor(drawingState.currentNSColor)
                 }
+                updateCursorForTool()
             }
 
         // Clear all
@@ -502,10 +613,12 @@ final class DrawingCanvasView: NSView {
 
     override func flagsChanged(with event: NSEvent) {
         // Modifier changes during drag cause shape type to update.
-        // The actual shape determination happens in mouseDragged via currentShapeType().
         if isDragging {
-            // Trigger a "drag" update with current position
             mouseDragged(with: event)
+        }
+        // Update cursor to reflect shape tool
+        if drawingState.activeTool != .spotlight {
+            updateCursorForTool()
         }
     }
 
@@ -527,6 +640,7 @@ final class DrawingCanvasView: NSView {
             } else if event.scrollingDeltaY < 0 {
                 drawingState.decreasePenWidth()
             }
+            updateCursorForTool()
         }
     }
 

--- a/src/ZoomacIt/Draw/ShapeRenderer.swift
+++ b/src/ZoomacIt/Draw/ShapeRenderer.swift
@@ -40,15 +40,15 @@ enum ShapeRenderer {
 
     /// Creates an arrow path where the **start point is the arrowhead tip**
     /// (ZoomIt-specific behavior — the arrow points toward where you started dragging).
-    static func arrowPath(from start: CGPoint, to end: CGPoint) -> NSBezierPath {
+    static func arrowPath(from start: CGPoint, to end: CGPoint, penWidth: CGFloat = 3.0) -> NSBezierPath {
         let path = NSBezierPath()
 
         // The shaft goes from end (tail) to start (tip)
         path.move(to: end)
         path.line(to: start)
 
-        // Arrowhead at the start point (tip)
-        let headLength: CGFloat = 20.0
+        // Arrowhead at the start point (tip) — scale with pen width
+        let headLength: CGFloat = max(20.0, penWidth * 3.0)
         let headAngle: CGFloat = .pi / 6  // 30 degrees
 
         let dx = end.x - start.x


### PR DESCRIPTION
## Summary

Draw mode cursor now visually indicates the active tool, matching Windows ZoomIt behaviour.

## Changes

- **Freehand** (no modifier): coloured dot cursor matching pen colour and width
- **Shift** held: line indicator
- **Control** held: rectangle indicator
- **Shift+Control** held: arrow indicator
- **Tab** held: ellipse indicator
- Cursor updates live when:
  - Colour changes (R/G/B/O/Y/P keys)
  - Pen width changes (⌃+scroll)
  - Modifier keys pressed/released

## Testing
- Verified on macOS 15.7.7
- All shape indicators render correctly
- Cursor transitions smoothly between tools