### PR TITLE
chore: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,9 +17,9 @@
 
 <!-- Check each item before requesting review. -->
 
-- [ ] ZoomIt との機能互換（操作や設定項目）が一致していることを確認しました。ZoomacIt 独自の機能の場合は、Owner とその機能の必要性について Issues でディスカッションしました。
-- [ ] ローカルマシンで動作を確認しました。
-- [ ] ユーザー向けドキュメントを記述し、内容が実際の挙動と一致していることを確認しました。
+- [ ] I confirmed feature compatibility with ZoomIt, including operations and settings items. For ZoomacIt-specific features, I discussed the need for the feature with the Owner in Issues.
+- [ ] I verified the behavior on my local machine.
+- [ ] I wrote user-facing documentation and confirmed that it matches the actual behavior.
 
 ## Screenshots / Recordings
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,41 +13,18 @@
 - [ ] Refactor / maintenance
 - [ ] Build / release / CI
 
-## Behavior and Compatibility
+## Acceptance Checklist
 
-<!-- For ZoomIt-compatible features, confirm that behavior and settings match the reference implementation. Use N/A with a short reason when this does not apply. -->
+<!-- Check each item before requesting review. If an item does not apply, explain why in the PR body. -->
 
-- [ ] I confirmed ZoomIt compatibility for related behavior.
-- [ ] I confirmed ZoomIt compatibility for related settings items.
-- [ ] I verified that any new or changed settings are exposed in the Settings UI when users need to configure them.
-- [ ] Not applicable: <!-- Explain why. -->
-
-## Local Verification
-
-<!-- Check the commands or manual verification you ran. Use N/A with a short reason when a check does not apply. -->
-
-- [ ] `make build`
-- [ ] `make test`
-- [ ] `make run` or equivalent local app launch
-- [ ] Manual verification on macOS:
-  <!-- Describe the workflow tested, including relevant hotkeys, permissions, settings, or UI states. -->
-- [ ] Not applicable: <!-- Explain why. -->
-
-## Documentation
-
-<!-- Update user-facing docs, design docs, or both when behavior, settings, shortcuts, permissions, or workflows change. -->
-
-- [ ] I updated user-facing documentation.
-- [ ] I updated design / implementation documentation.
-- [ ] I updated screenshots or recordings, if needed.
-- [ ] Not applicable: <!-- Explain why. -->
-
-## Project Files
-
-<!-- The Xcode project is generated from src/project.yml. -->
-
-- [ ] If I changed `src/project.yml`, I ran `make generate` and committed the generated project changes.
-- [ ] Not applicable: <!-- Explain why. -->
+- [ ] The change scope and user-visible behavior are clearly described.
+- [ ] For ZoomIt-compatible features, I compared the relevant behavior and settings items with ZoomIt.
+- [ ] Any new or changed settings that users need to configure are exposed in the Settings UI.
+- [ ] I verified the implemented behavior locally on macOS, including relevant UI states, hotkeys, permissions, and settings.
+- [ ] I updated user-facing documentation and/or design documentation when behavior, settings, shortcuts, permissions, or workflows changed.
+- [ ] I included screenshots or recordings for UI-facing changes when they help reviewers understand the result.
+- [ ] I updated generated project files or related metadata when source configuration changes required it.
+- [ ] I explained any checklist item that does not apply.
 
 ## Screenshots / Recordings
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,58 @@
+## Summary
+
+<!-- Describe what changed and why. Keep it focused on the user-visible behavior or maintenance goal. -->
+
+## Type of Change
+
+<!-- Check all that apply. -->
+
+- [ ] Feature
+- [ ] Bug fix
+- [ ] Documentation
+- [ ] Tests
+- [ ] Refactor / maintenance
+- [ ] Build / release / CI
+
+## Behavior and Compatibility
+
+<!-- For ZoomIt-compatible features, confirm that behavior and settings match the reference implementation. Use N/A with a short reason when this does not apply. -->
+
+- [ ] I confirmed ZoomIt compatibility for related behavior.
+- [ ] I confirmed ZoomIt compatibility for related settings items.
+- [ ] I verified that any new or changed settings are exposed in the Settings UI when users need to configure them.
+- [ ] Not applicable: <!-- Explain why. -->
+
+## Local Verification
+
+<!-- Check the commands or manual verification you ran. Use N/A with a short reason when a check does not apply. -->
+
+- [ ] `make build`
+- [ ] `make test`
+- [ ] `make run` or equivalent local app launch
+- [ ] Manual verification on macOS:
+  <!-- Describe the workflow tested, including relevant hotkeys, permissions, settings, or UI states. -->
+- [ ] Not applicable: <!-- Explain why. -->
+
+## Documentation
+
+<!-- Update user-facing docs, design docs, or both when behavior, settings, shortcuts, permissions, or workflows change. -->
+
+- [ ] I updated user-facing documentation.
+- [ ] I updated design / implementation documentation.
+- [ ] I updated screenshots or recordings, if needed.
+- [ ] Not applicable: <!-- Explain why. -->
+
+## Project Files
+
+<!-- The Xcode project is generated from src/project.yml. -->
+
+- [ ] If I changed `src/project.yml`, I ran `make generate` and committed the generated project changes.
+- [ ] Not applicable: <!-- Explain why. -->
+
+## Screenshots / Recordings
+
+<!-- Add screenshots or recordings for UI-facing changes. Drag files here or link them. -->
+
+## Related Issues / Notes for Reviewers
+
+<!-- Link issues, follow-up work, or areas where reviewers should pay special attention. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,16 +15,11 @@
 
 ## Acceptance Checklist
 
-<!-- Check each item before requesting review. If an item does not apply, explain why in the PR body. -->
+<!-- Check each item before requesting review. -->
 
-- [ ] The change scope and user-visible behavior are clearly described.
-- [ ] For ZoomIt-compatible features, I compared the relevant behavior and settings items with ZoomIt.
-- [ ] Any new or changed settings that users need to configure are exposed in the Settings UI.
-- [ ] I verified the implemented behavior locally on macOS, including relevant UI states, hotkeys, permissions, and settings.
-- [ ] I updated user-facing documentation and/or design documentation when behavior, settings, shortcuts, permissions, or workflows changed.
-- [ ] I included screenshots or recordings for UI-facing changes when they help reviewers understand the result.
-- [ ] I updated generated project files or related metadata when source configuration changes required it.
-- [ ] I explained any checklist item that does not apply.
+- [ ] ZoomIt との機能互換（操作や設定項目）が一致していることを確認しました。ZoomacIt 独自の機能の場合は、Owner とその機能の必要性について Issues でディスカッションしました。
+- [ ] ローカルマシンで動作を確認しました。
+- [ ] ユーザー向けドキュメントを記述し、内容が実際の挙動と一致していることを確認しました。
 
 ## Screenshots / Recordings
 


### PR DESCRIPTION
## Summary

Adds a default GitHub pull request template for ZoomacIt.

The template now uses a concise acceptance checklist focused on PR readiness:

- Confirm feature compatibility with ZoomIt, including operations and settings items. For ZoomacIt-specific features, discuss the need for the feature with the Owner in Issues.
- Verify behavior on a local machine.
- Write user-facing documentation and confirm that it matches the actual behavior.

## Verification

- Ran a whitespace/formatting diff check
- Manually reviewed the Markdown structure
- App build/test not run because this is a GitHub metadata-only Markdown change
