### PR TITLE
ci: skip app CI for metadata-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,10 @@ name: CI
 on:
   pull_request:
     branches: [main]
+    paths:
+      - 'src/**'
+      - 'Makefile'
+      - '.github/workflows/ci.yml'
 
 concurrency:
   group: ci-${{ github.ref }}


### PR DESCRIPTION
## Summary

Adds a path allowlist to the CI pull request trigger so the macOS app build/test workflow only runs for changes that can affect the app or CI itself.

CI will run for:

- `src/**`
- `Makefile`
- `.github/workflows/ci.yml`

Metadata-only or documentation-only changes, such as `.github/pull_request_template.md`, will no longer trigger the app CI workflow.

## Verification

- Ran `git diff --check`
- Parsed `.github/workflows/ci.yml` locally with Ruby YAML parser
- App build/test not run because this is a workflow-only change
