### PR TITLE
feat(Draw): add configurable default draw shape setting

### DIFF
--- a/src/ZoomacIt/Models/DrawingState.swift
+++ b/src/ZoomacIt/Models/DrawingState.swift
@@ -95,20 +95,23 @@ final class DrawingState {
     }
 
     /// Determine the current shape type based on modifier flags and Tab key state.
+    /// When a non-freehand default is configured, the modifier that would normally
+    /// produce that shape gives freehand instead (swap behavior).
     func currentShapeType(modifiers: NSEvent.ModifierFlags) -> ShapeType {
         let hasShift = modifiers.contains(.shift)
         let hasControl = modifiers.contains(.control)
+        let defaultShape = Settings.shared.defaultDrawShape
 
         if isTabHeld {
-            return .ellipse
+            return defaultShape == .ellipse ? .freehand : .ellipse
         } else if hasShift && hasControl {
-            return .arrow
+            return defaultShape == .arrow ? .freehand : .arrow
         } else if hasShift {
-            return .line
+            return defaultShape == .line ? .freehand : .line
         } else if hasControl {
-            return .rectangle
+            return defaultShape == .rectangle ? .freehand : .rectangle
         } else {
-            return Settings.shared.defaultDrawShape
+            return defaultShape
         }
     }
 

--- a/src/ZoomacIt/Models/DrawingState.swift
+++ b/src/ZoomacIt/Models/DrawingState.swift
@@ -108,7 +108,7 @@ final class DrawingState {
         } else if hasControl {
             return .rectangle
         } else {
-            return .freehand
+            return Settings.shared.defaultDrawShape
         }
     }
 

--- a/src/ZoomacIt/Models/Settings.swift
+++ b/src/ZoomacIt/Models/Settings.swift
@@ -70,6 +70,7 @@ final class Settings: @unchecked Sendable {
         // Draw
         static let defaultPenColor = "drawDefaultPenColor"
         static let defaultPenWidth = "drawDefaultPenWidth"
+        static let defaultDrawShape = "drawDefaultShape"
         static let highlighterOpacity = "drawHighlighterOpacity"
         static let highlighterWidthMultiplier = "drawHighlighterWidthMultiplier"
         static let spotlightDarkness = "drawSpotlightDarkness"
@@ -110,6 +111,7 @@ final class Settings: @unchecked Sendable {
             // Draw
             Keys.defaultPenColor: PenColor.red.rawValue,
             Keys.defaultPenWidth: 3.0,
+            Keys.defaultDrawShape: "freehand",
             Keys.highlighterOpacity: 0.35,
             Keys.highlighterWidthMultiplier: 4.0,
             Keys.spotlightDarkness: 0.6,
@@ -185,6 +187,11 @@ final class Settings: @unchecked Sendable {
     var defaultPenWidth: CGFloat {
         get { CGFloat(defaults.double(forKey: Keys.defaultPenWidth)) }
         set { defaults.set(Double(newValue), forKey: Keys.defaultPenWidth) }
+    }
+
+    var defaultDrawShape: ShapeType {
+        get { ShapeType(rawValue: defaults.string(forKey: Keys.defaultDrawShape) ?? "freehand") ?? .freehand }
+        set { defaults.set(newValue.rawValue, forKey: Keys.defaultDrawShape) }
     }
 
     var highlighterOpacity: CGFloat {

--- a/src/ZoomacIt/Models/Stroke.swift
+++ b/src/ZoomacIt/Models/Stroke.swift
@@ -1,7 +1,7 @@
 import AppKit
 
 /// The type of shape being drawn.
-enum ShapeType: Sendable {
+enum ShapeType: String, Sendable, CaseIterable {
     case freehand
     case line
     case rectangle

--- a/src/ZoomacIt/Settings/DrawTab.swift
+++ b/src/ZoomacIt/Settings/DrawTab.swift
@@ -5,6 +5,7 @@ struct DrawTab: View {
 
     @AppStorage(Settings.Keys.defaultPenColor) private var penColorRaw: String = PenColor.red.rawValue
     @AppStorage(Settings.Keys.defaultPenWidth) private var penWidth: Double = 3.0
+    @AppStorage(Settings.Keys.defaultDrawShape) private var drawShapeRaw: String = "freehand"
     @AppStorage(Settings.Keys.highlighterOpacity) private var highlighterOpacity: Double = 0.35
     @AppStorage(Settings.Keys.highlighterWidthMultiplier) private var highlighterMultiplier: Double = 4.0
     @AppStorage(Settings.Keys.spotlightDarkness) private var spotlightDarkness: Double = 0.6
@@ -46,6 +47,12 @@ struct DrawTab: View {
                     Text("\(Int(penWidth)) pt")
                         .frame(width: 40, alignment: .trailing)
                         .monospacedDigit()
+                }
+
+                Picker("Default Shape", selection: $drawShapeRaw) {
+                    ForEach(ShapeType.allCases, id: \.self) { shape in
+                        Text(shape.rawValue.capitalized).tag(shape.rawValue)
+                    }
                 }
             }
 

--- a/src/ZoomacItTests/DrawingStateTests.swift
+++ b/src/ZoomacItTests/DrawingStateTests.swift
@@ -3,6 +3,11 @@ import XCTest
 
 final class DrawingStateTests: XCTestCase {
 
+    override func setUp() {
+        super.setUp()
+        Settings.shared.defaultDrawShape = .freehand
+    }
+
     func testDefaultState() {
         let state = DrawingState()
         XCTAssertEqual(state.penWidth, 3.0)


### PR DESCRIPTION
Closes #40

## Summary

Adds a user-configurable default draw shape, so users who primarily draw rectangles (or any other shape) don't have to hold modifier keys every time.

## Changes

- **Settings → Draw → Default Shape**: Picker with all shape types (freehand, line, rectangle, ellipse, arrow)
- **Persists across restarts** via UserDefaults (key: `drawDefaultShape`)
- **Defaults to freehand** for existing users (no behavior change unless configured)
- When no modifier keys are held during draw, the configured default shape is used instead of hardcoded freehand
- `ShapeType` now conforms to `RawRepresentable<String>` + `CaseIterable`

## Testing

- All 120 existing tests pass
- Verified: changing default to rectangle → drawing without modifiers creates rectangles
- Modifier keys still override as before (Shift=line, Control=rect, Tab=ellipse, Shift+Control=arrow)